### PR TITLE
Update init.lua for compatibility with the MAME UI

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -69,8 +69,8 @@ function defenderlr.startplugin()
 		if frame_subscription ~= nil then
 			frame_subscription:unsubscribe()
 		end
-		reset_subscription:unsubscribe()
-		stop_subscription:unsubscribe()
+		--reset_subscription:unsubscribe()
+		--stop_subscription:unsubscribe()
 	end
 
 	local function init_plugin()


### PR DESCRIPTION
Removed the unsubscribe() method calls for reset_subscription and stop_subscription.   

unsubscribing these two items causes the defenderlr plugin to not work when games (defender or stargate) are launched via the interactive MAME UI.   This is because the MAME UI launches with a romname value of "___empty" which causes the plugin to skip to its cleanup() function, where all events are unsubscribed immediately and no thus no longer work for any subsequent game launches from the MAME UI.

Removing them retains both command-line and MAME UI compatibility,